### PR TITLE
Paginacao passa a ser Antigos e Recentes

### DIFF
--- a/_source/index.html
+++ b/_source/index.html
@@ -57,18 +57,18 @@ sitemap_frequency: weekly
 
 <div id="post-pagination">
   {% if paginator.previous_page %}
-  <p class="anteriores">
+  <p class="antigos">
     {% if paginator.previous_page == 1 %}
-    <a href="/">← Anteriores</a>
+    <a href="/">Recentes →</a>
     {% else %}
-    <a href="/page{{paginator.previous_page}}">← Anteriores</a>
+    <a href="/page{{paginator.previous_page}}">Recentes →</a>
     {% endif %}
   </p>
   {% endif %}
 
   {% if paginator.next_page %}
-  <p class="proximos">
-    <a href="/page{{paginator.next_page}}">Próximos →</a>
+  <p class="recentes">
+    <a href="/page{{paginator.next_page}}">← Antigos</a>
   </p>
   {% endif %}
 </div>

--- a/_source/styles/blog.less
+++ b/_source/styles/blog.less
@@ -348,11 +348,11 @@ strong {
 			}
 		}
 
-		&.anteriores {
+		&.recentes {
 			left: 50px;
 		}
 
-		&.proximos {
+		&.antigos {
 			right: 50px;
 			text-align: right;
 		}


### PR DESCRIPTION
Renomeia "Anteriores e Próximos" pra Antigos e Recentes e inverte a posição dos mesmo. 
Assim, os Próximos são Antigos e agora ficam na esquerda (voltando) e os Anteriores são Recentes e ficam na direita (avançando). 
