### PR TITLE
Over no link Continue Lendo

### DIFF
--- a/_source/styles/blog.less
+++ b/_source/styles/blog.less
@@ -656,10 +656,14 @@ header#main {
 				}
 
 				&.leia-mais {
-					display: block;
-					color: #333;
+					display: inline-block;
+					color: #666;
 					font-weight: bold;
 					margin-top: 20px;
+
+					&:hover {
+						color: #000;
+					}
 				}
 			}
 		} // fim de article


### PR DESCRIPTION
O link "continue lendo" tava sem :hover, pus uma cor.
Também tava com display:block, fazendo com que a linha toda do elemento fosse uma área de link, mesmo onde não tinha texto, assim ficava estranho passar o mouse na área vazia ao lado do texto "Continue lendo" e o cursor mudar pra pointer e tu não saber exatamente onde estava clicando. Mudei pra display:inline-block pra resolver isso.
